### PR TITLE
✨ Implement string formatting for integers and floats in rule sets

### DIFF
--- a/pkg/rules/float_test.go
+++ b/pkg/rules/float_test.go
@@ -176,3 +176,360 @@ func TestFloatRuleSet_Evaluate(t *testing.T) {
 func TestFloatRuleSet_WithNil(t *testing.T) {
 	testhelpers.MustImplementWithNil[float64](t, rules.Float64())
 }
+
+// TestFloatRuleSet_Apply_StringOutput tests:
+// - Outputs string values when output is a string type
+// - Uses appropriate precision
+func TestFloatRuleSet_Apply_StringOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float64]
+		input    interface{}
+		expected string
+	}{
+		{"DefaultPrecision", rules.Float64(), 123.456789012345, "123.456789012345"},
+		{"WithFixedOutput2", rules.Float64().WithFixedOutput(2), 123.456789, "123.46"},
+		{"WithFixedOutput0", rules.Float64().WithFixedOutput(0), 123.456789, "123"},
+		{"WithFixedOutput5", rules.Float64().WithFixedOutput(5), 123.456789, "123.45679"},
+		{"IntegerValue", rules.Float64(), 42.0, "42"},
+		{"Negative", rules.Float64(), -123.456, "-123.456"},
+		{"Zero", rules.Float64(), 0.0, "0"},
+		{"SmallValue", rules.Float64(), 0.001, "0.001"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_Apply_PointerToStringOutput tests:
+// - Outputs string values when output is a pointer to string type
+// - Handles nil pointer by creating a new string
+func TestFloatRuleSet_Apply_PointerToStringOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float64]
+		input    interface{}
+		expected string
+	}{
+		{"DefaultPrecision", rules.Float64(), 123.456, "123.456"},
+		{"WithFixedOutput2", rules.Float64().WithFixedOutput(2), 123.456, "123.46"},
+		{"Negative", rules.Float64(), -42.5, "-42.5"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"_NilPointer", func(t *testing.T) {
+			var out *string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out == nil {
+				t.Error("Expected pointer to be non-nil")
+				return
+			}
+
+			if *out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, *out)
+			}
+		})
+
+		t.Run(tt.name+"_ExistingPointer", func(t *testing.T) {
+			existing := "existing"
+			out := &existing
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out == nil {
+				t.Error("Expected pointer to be non-nil")
+				return
+			}
+
+			if *out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, *out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_Apply_StringOutput_Float32 tests:
+// - String output works with float32 type
+func TestFloatRuleSet_Apply_StringOutput_Float32(t *testing.T) {
+	var out string
+	err := rules.Float32().Apply(context.Background(), float32(123.456), &out)
+
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+		return
+	}
+
+	// Float32 should format with appropriate precision
+	if out == "" {
+		t.Error("Expected non-empty string")
+	}
+}
+
+// TestFloatRuleSet_Apply_StringOutput_WithRounding tests:
+// - When rounding is applied, the value is rounded first
+// - Output formatting uses 'g' format by default (no trailing zeros)
+func TestFloatRuleSet_Apply_StringOutput_WithRounding(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float64]
+		input    float64
+		expected string
+	}{
+		{"RoundingHalfEven_Precision2", rules.Float64().WithRounding(rules.RoundingHalfEven, 2), 123.456, "123.46"},
+		{"RoundingHalfUp_Precision2", rules.Float64().WithRounding(rules.RoundingHalfUp, 2), 123.455, "123.46"},
+		{"RoundingDown_Precision2", rules.Float64().WithRounding(rules.RoundingDown, 2), 123.456, "123.45"},
+		{"RoundingUp_Precision2", rules.Float64().WithRounding(rules.RoundingUp, 2), 123.451, "123.46"},
+		{"RoundingHalfEven_Precision0", rules.Float64().WithRounding(rules.RoundingHalfEven, 0), 123.5, "124"},
+		{"RoundingDown_Precision0", rules.Float64().WithRounding(rules.RoundingDown, 0), 123.9, "123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_WithFixedOutput tests:
+// - WithFixedOutput controls string output precision
+// - Values are zero-padded to the specified precision
+func TestFloatRuleSet_WithFixedOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float64]
+		input    float64
+		expected string
+	}{
+		{"Precision0", rules.Float64().WithFixedOutput(0), 123.456, "123"},
+		{"Precision1", rules.Float64().WithFixedOutput(1), 123.456, "123.5"},
+		{"Precision2", rules.Float64().WithFixedOutput(2), 123.456, "123.46"},
+		{"Precision3", rules.Float64().WithFixedOutput(3), 123.456, "123.456"},
+		{"Precision4_ZeroPad", rules.Float64().WithFixedOutput(4), 123.4, "123.4000"},
+		{"Precision2_Integer", rules.Float64().WithFixedOutput(2), 42.0, "42.00"},
+		{"Precision2_Negative", rules.Float64().WithFixedOutput(2), -123.456, "-123.46"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_WithFixedOutput_WithRounding tests:
+// - WithFixedOutput and WithRounding can be combined
+// - Rounding is applied first, then output is formatted with fixed precision
+func TestFloatRuleSet_WithFixedOutput_WithRounding(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float64]
+		input    float64
+		expected string
+	}{
+		// Rounding to 2 decimal places, output with 2 decimal places
+		{"Round2_Output2", rules.Float64().WithRounding(rules.RoundingHalfEven, 2).WithFixedOutput(2), 123.456, "123.46"},
+		// Rounding to 2 decimal places, output with 4 decimal places (zero-padded)
+		{"Round2_Output4", rules.Float64().WithRounding(rules.RoundingHalfEven, 2).WithFixedOutput(4), 123.456, "123.4600"},
+		// Rounding to 0 decimal places, output with 2 decimal places (zero-padded)
+		{"Round0_Output2", rules.Float64().WithRounding(rules.RoundingHalfEven, 0).WithFixedOutput(2), 123.456, "123.00"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_String_WithFixedOutput tests:
+// - Serializes to WithFixedOutput(...)
+func TestFloatRuleSet_String_WithFixedOutput(t *testing.T) {
+	ruleSet := rules.Float64().WithFixedOutput(2)
+
+	expected := "FloatRuleSet[float64].WithFixedOutput(2)"
+	if s := ruleSet.String(); s != expected {
+		t.Errorf("Expected rule set to be %s, got %s", expected, s)
+	}
+}
+
+// TestFloatRuleSet_WithFixedOutput_EdgeCases tests edge cases for WithFixedOutput:
+// - Zero-padding when value has no decimals
+// - Precision 0 with integer values
+// - Values that already have exact precision
+func TestFloatRuleSet_WithFixedOutput_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float64]
+		input    float64
+		expected string
+	}{
+		// Zero-padding integer values
+		{"ZeroPad_Integer", rules.Float64().WithFixedOutput(3), 100.0, "100.000"},
+		// Precision 0 with integer (no decimal point in formatted output)
+		{"Precision0_Integer", rules.Float64().WithFixedOutput(0), 100.0, "100"},
+		// Value already has exact precision needed (no padding required)
+		{"ExactPrecision_NoPadding", rules.Float64().WithFixedOutput(2), 123.45, "123.45"},
+		// Value with exact precision from rounding
+		{"ExactPrecision_FromFormat", rules.Float64().WithFixedOutput(6), 123.456789, "123.456789"},
+		// Zero value with padding
+		{"Zero_WithPadding", rules.Float64().WithFixedOutput(3), 0.0, "0.000"},
+		// Small value with extra padding
+		{"Small_WithPadding", rules.Float64().WithFixedOutput(5), 0.1, "0.10000"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_WithRounding_TrailingZeros tests that trailing zeros are trimmed after rounding:
+// - Rounding to a precision where result ends in zeros
+// - Integer results after rounding
+func TestFloatRuleSet_WithRounding_TrailingZeros(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float64]
+		input    float64
+		expected string
+	}{
+		// Rounding results in trailing zeros that should be trimmed
+		{"TrailingZeros_Trimmed", rules.Float64().WithRounding(rules.RoundingHalfEven, 3), 123.400, "123.4"},
+		// Rounding to integer (all decimals become zero)
+		{"AllZeros_Trimmed", rules.Float64().WithRounding(rules.RoundingHalfEven, 2), 100.00, "100"},
+		// No trailing zeros to trim
+		{"NoTrailingZeros", rules.Float64().WithRounding(rules.RoundingHalfEven, 2), 123.45, "123.45"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_Float32_StringOutput tests string output with float32 type:
+// - Exercises the float32 branch in formatFloat
+func TestFloatRuleSet_Float32_StringOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		ruleSet  *rules.FloatRuleSet[float32]
+		input    float32
+		expected string
+	}{
+		{"Default", rules.Float32(), float32(123.456), "123.456"},
+		{"WithFixedOutput", rules.Float32().WithFixedOutput(2), float32(123.456), "123.46"},
+		{"WithRounding", rules.Float32().WithRounding(rules.RoundingHalfEven, 1), float32(123.456), "123.5"},
+		{"Integer", rules.Float32(), float32(42.0), "42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out string
+			err := tt.ruleSet.Apply(context.Background(), tt.input, &out)
+
+			if err != nil {
+				t.Errorf("Expected no errors, got: %v", err)
+				return
+			}
+
+			if out != tt.expected {
+				t.Errorf("Expected string %q, got %q", tt.expected, out)
+			}
+		})
+	}
+}
+
+// TestFloatRuleSet_WithFixedOutput_PointerToString tests pointer to string output with fixed precision
+func TestFloatRuleSet_WithFixedOutput_PointerToString(t *testing.T) {
+	var out *string
+	err := rules.Float64().WithFixedOutput(2).Apply(context.Background(), 123.4, &out)
+
+	if err != nil {
+		t.Errorf("Expected no errors, got: %v", err)
+		return
+	}
+
+	if out == nil {
+		t.Error("Expected pointer to be non-nil")
+		return
+	}
+
+	if *out != "123.40" {
+		t.Errorf("Expected string %q, got %q", "123.40", *out)
+	}
+}

--- a/pkg/rules/rounding.go
+++ b/pkg/rules/rounding.go
@@ -44,6 +44,7 @@ func (v *IntRuleSet[T]) WithRounding(rounding Rounding) *IntRuleSet[T] {
 		parent:   v,
 		base:     v.base,
 		required: v.required,
+		withNil:  v.withNil,
 		rounding: rounding,
 		label:    fmt.Sprintf("WithRounding(%s)", rounding.String()),
 	}
@@ -57,11 +58,31 @@ func (v *IntRuleSet[T]) WithRounding(rounding Rounding) *IntRuleSet[T] {
 // - For best results, consider using int for your math and data storage/transfer.
 func (v *FloatRuleSet[T]) WithRounding(rounding Rounding, precision int) *FloatRuleSet[T] {
 	return &FloatRuleSet[T]{
-		strict:    v.strict,
-		parent:    v,
-		required:  v.required,
-		rounding:  rounding,
-		precision: precision,
-		label:     fmt.Sprintf("WithRounding(%s, %d)", rounding.String(), precision),
+		strict:          v.strict,
+		parent:          v,
+		required:        v.required,
+		withNil:         v.withNil,
+		rounding:        rounding,
+		precision:       precision,
+		outputPrecision: v.outputPrecision,
+		label:           fmt.Sprintf("WithRounding(%s, %d)", rounding.String(), precision),
+	}
+}
+
+// WithFixedOutput returns a new child RuleSet that uses a fixed precision for string output.
+// When outputting to a string type, the value will be zero-padded to exactly the specified number of decimal places.
+// This is useful for consistent formatting where you always want the same number of decimal places.
+//
+// Example: WithFixedOutput(2) will format 123.4 as "123.40" and 123.456 as "123.46" (after rounding if applicable).
+func (v *FloatRuleSet[T]) WithFixedOutput(precision int) *FloatRuleSet[T] {
+	return &FloatRuleSet[T]{
+		strict:          v.strict,
+		parent:          v,
+		required:        v.required,
+		withNil:         v.withNil,
+		rounding:        v.rounding,
+		precision:       v.precision,
+		outputPrecision: precision,
+		label:           fmt.Sprintf("WithFixedOutput(%d)", precision),
 	}
 }


### PR DESCRIPTION
- Added `formatInt` and `formatFloat` functions to handle string conversion for integers and floats, respectively.
- Updated `IntRuleSet` and `FloatRuleSet` to utilize these formatting functions when outputting string values.
- Enhanced comments for clarity on the behavior of `WithBase` and output precision settings.

This improves the consistency of number formatting across different rule sets and ensures that string outputs adhere to specified bases and precision settings.

Resolves #7