### PR TITLE
Refactor rule set methods to use clone for creating child rule sets

### DIFF
--- a/pkg/rules/any.go
+++ b/pkg/rules/any.go
@@ -34,6 +34,16 @@ func Any() *AnyRuleSet {
 	return &backgroundAnyRuleSet
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (v *AnyRuleSet) clone() *AnyRuleSet {
+	return &AnyRuleSet{
+		required:  v.required,
+		forbidden: v.forbidden,
+		withNil:   v.withNil,
+		parent:    v,
+	}
+}
+
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
 func (v *AnyRuleSet) Required() bool {
 	return v.required
@@ -42,38 +52,29 @@ func (v *AnyRuleSet) Required() bool {
 // WithRequired returns a new child rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (v *AnyRuleSet) WithRequired() *AnyRuleSet {
-	return &AnyRuleSet{
-		required:  true,
-		forbidden: v.forbidden,
-		withNil:   v.withNil,
-		parent:    v,
-		label:     "WithRequired()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithForbidden returns a new child rule set that requires values to be nil or omitted.
 // When a value is present, validation fails with an error.
 func (v *AnyRuleSet) WithForbidden() *AnyRuleSet {
-	return &AnyRuleSet{
-		required:  v.required,
-		forbidden: true,
-		withNil:   v.withNil,
-		parent:    v,
-		label:     "WithForbidden()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.forbidden = true
+	newRuleSet.label = "WithForbidden()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (v *AnyRuleSet) WithNil() *AnyRuleSet {
-	return &AnyRuleSet{
-		required:  v.required,
-		forbidden: v.forbidden,
-		withNil:   true,
-		parent:    v,
-		label:     "WithNil()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // Apply performs validation of a RuleSet against a value and assigns the value to the output.
@@ -147,13 +148,9 @@ func (v *AnyRuleSet) Evaluate(ctx context.Context, value any) errors.ValidationE
 // WithRule returns a new child rule set that applies a custom validation rule.
 // The custom rule is evaluated during validation and any errors it returns are included in the validation result.
 func (v *AnyRuleSet) WithRule(rule Rule[any]) *AnyRuleSet {
-	return &AnyRuleSet{
-		required:  v.required,
-		forbidden: v.forbidden,
-		withNil:   v.withNil,
-		rule:      rule,
-		parent:    v,
-	}
+	newRuleSet := v.clone()
+	newRuleSet.rule = rule
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.

--- a/pkg/rules/constant.go
+++ b/pkg/rules/constant.go
@@ -57,6 +57,15 @@ func (ruleSet *ConstantRuleSet[T]) Required() bool {
 	return ruleSet.required
 }
 
+// clone returns a shallow copy of the rule set.
+func (ruleSet *ConstantRuleSet[T]) clone() *ConstantRuleSet[T] {
+	return &ConstantRuleSet[T]{
+		value:    ruleSet.value,
+		required: ruleSet.required,
+		withNil:  ruleSet.withNil,
+	}
+}
+
 // WithRequired returns a new child rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (ruleSet *ConstantRuleSet[T]) WithRequired() *ConstantRuleSet[T] {
@@ -64,22 +73,18 @@ func (ruleSet *ConstantRuleSet[T]) WithRequired() *ConstantRuleSet[T] {
 		return ruleSet
 	}
 
-	return &ConstantRuleSet[T]{
-		value:    ruleSet.value,
-		required: true,
-		withNil:  ruleSet.withNil,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.required = true
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (ruleSet *ConstantRuleSet[T]) WithNil() *ConstantRuleSet[T] {
-	return &ConstantRuleSet[T]{
-		value:    ruleSet.value,
-		required: ruleSet.required,
-		withNil:  true,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.withNil = true
+	return newRuleSet
 }
 
 // Apply validates a RuleSet against an input value and assigns the validated value to output.

--- a/pkg/rules/float.go
+++ b/pkg/rules/float.go
@@ -47,22 +47,29 @@ func Float64() *FloatRuleSet[float64] {
 	return &baseFloat64
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (v *FloatRuleSet[T]) clone() *FloatRuleSet[T] {
+	return &FloatRuleSet[T]{
+		strict:          v.strict,
+		required:        v.required,
+		withNil:         v.withNil,
+		rounding:        v.rounding,
+		precision:       v.precision,
+		outputPrecision: v.outputPrecision,
+		parent:          v,
+	}
+}
+
 // WithStrict returns a new child RuleSet that disables type coercion.
 // When strict mode is enabled, validation only succeeds if the value is already the correct type.
 //
 // With number types, any type will work in strict mode as long as it can be converted
 // deterministically and without loss.
 func (v *FloatRuleSet[T]) WithStrict() *FloatRuleSet[T] {
-	return &FloatRuleSet[T]{
-		strict:          true,
-		parent:          v,
-		required:        v.required,
-		withNil:         v.withNil,
-		rounding:        v.rounding,
-		precision:       v.precision,
-		outputPrecision: v.outputPrecision,
-		label:           "WithStrict()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.strict = true
+	newRuleSet.label = "WithStrict()"
+	return newRuleSet
 }
 
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
@@ -73,32 +80,20 @@ func (v *FloatRuleSet[T]) Required() bool {
 // WithRequired returns a new child rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (v *FloatRuleSet[T]) WithRequired() *FloatRuleSet[T] {
-	return &FloatRuleSet[T]{
-		strict:          v.strict,
-		parent:          v,
-		required:        true,
-		withNil:         v.withNil,
-		rounding:        v.rounding,
-		precision:       v.precision,
-		outputPrecision: v.outputPrecision,
-		label:           "WithRequired()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (v *FloatRuleSet[T]) WithNil() *FloatRuleSet[T] {
-	return &FloatRuleSet[T]{
-		strict:          v.strict,
-		parent:          v,
-		required:        v.required,
-		withNil:         true,
-		rounding:        v.rounding,
-		precision:       v.precision,
-		outputPrecision: v.outputPrecision,
-		label:           "WithNil()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // Apply performs validation of a RuleSet against a value and assigns the result to the output parameter.
@@ -225,32 +220,20 @@ func (ruleSet *FloatRuleSet[T]) noConflict(rule Rule[T]) *FloatRuleSet[T] {
 		return ruleSet
 	}
 
-	return &FloatRuleSet[T]{
-		strict:          ruleSet.strict,
-		rule:            ruleSet.rule,
-		required:        ruleSet.required,
-		withNil:         ruleSet.withNil,
-		parent:          newParent,
-		rounding:        ruleSet.rounding,
-		precision:       ruleSet.precision,
-		outputPrecision: ruleSet.outputPrecision,
-		label:           ruleSet.label,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = ruleSet.rule
+	newRuleSet.parent = newParent
+	newRuleSet.label = ruleSet.label
+	return newRuleSet
 }
 
 // WithRule returns a new child rule set that applies a custom validation rule.
 // The custom rule is evaluated during validation and any errors it returns are included in the validation result.
 func (ruleSet *FloatRuleSet[T]) WithRule(rule Rule[T]) *FloatRuleSet[T] {
-	return &FloatRuleSet[T]{
-		strict:          ruleSet.strict,
-		parent:          ruleSet.noConflict(rule),
-		rule:            rule,
-		required:        ruleSet.required,
-		withNil:         ruleSet.withNil,
-		rounding:        ruleSet.rounding,
-		precision:       ruleSet.precision,
-		outputPrecision: ruleSet.outputPrecision,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = rule
+	newRuleSet.parent = ruleSet.noConflict(rule)
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.

--- a/pkg/rules/int.go
+++ b/pkg/rules/int.go
@@ -126,21 +126,28 @@ func Uint64() *IntRuleSet[uint64] {
 	return &baseUint64
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (v *IntRuleSet[T]) clone() *IntRuleSet[T] {
+	return &IntRuleSet[T]{
+		strict:   v.strict,
+		base:     v.base,
+		required: v.required,
+		withNil:  v.withNil,
+		rounding: v.rounding,
+		parent:   v,
+	}
+}
+
 // WithStrict returns a new child RuleSet that disables type coercion.
 // When strict mode is enabled, validation only succeeds if the value is already the correct type.
 //
 // With number types, any type will work in strict mode as long as it can be converted
 // deterministically and without loss.
 func (v *IntRuleSet[T]) WithStrict() *IntRuleSet[T] {
-	return &IntRuleSet[T]{
-		strict:   true,
-		parent:   v,
-		base:     v.base,
-		required: v.required,
-		withNil:  v.withNil,
-		rounding: v.rounding,
-		label:    "WithStrict()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.strict = true
+	newRuleSet.label = "WithStrict()"
+	return newRuleSet
 }
 
 // WithBase returns a new child rule set that uses the specified base for string-to-number conversion and number-to-string conversion.
@@ -150,15 +157,10 @@ func (v *IntRuleSet[T]) WithStrict() *IntRuleSet[T] {
 //
 // The default is base 10.
 func (v *IntRuleSet[T]) WithBase(base int) *IntRuleSet[T] {
-	return &IntRuleSet[T]{
-		strict:   v.strict,
-		parent:   v,
-		base:     base,
-		required: v.required,
-		withNil:  v.withNil,
-		rounding: v.rounding,
-		label:    fmt.Sprintf("WithBase(%d)", base),
-	}
+	newRuleSet := v.clone()
+	newRuleSet.base = base
+	newRuleSet.label = fmt.Sprintf("WithBase(%d)", base)
+	return newRuleSet
 }
 
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
@@ -169,30 +171,20 @@ func (v *IntRuleSet[T]) Required() bool {
 // WithRequired returns a new child rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (v *IntRuleSet[T]) WithRequired() *IntRuleSet[T] {
-	return &IntRuleSet[T]{
-		strict:   v.strict,
-		parent:   v,
-		base:     v.base,
-		required: true,
-		withNil:  v.withNil,
-		rounding: v.rounding,
-		label:    "WithRequired()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (v *IntRuleSet[T]) WithNil() *IntRuleSet[T] {
-	return &IntRuleSet[T]{
-		strict:   v.strict,
-		parent:   v,
-		base:     v.base,
-		required: v.required,
-		withNil:  true,
-		rounding: v.rounding,
-		label:    "WithNil()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // Apply performs validation of a RuleSet against a value and assigns the result to the output parameter.
@@ -313,30 +305,20 @@ func (ruleSet *IntRuleSet[T]) withoutConflicts(rule Rule[T]) *IntRuleSet[T] {
 		return ruleSet
 	}
 
-	return &IntRuleSet[T]{
-		strict:   ruleSet.strict,
-		base:     ruleSet.base,
-		rule:     ruleSet.rule,
-		required: ruleSet.required,
-		withNil:  ruleSet.withNil,
-		parent:   newParent,
-		rounding: ruleSet.rounding,
-		label:    ruleSet.label,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = ruleSet.rule
+	newRuleSet.parent = newParent
+	newRuleSet.label = ruleSet.label
+	return newRuleSet
 }
 
 // WithRule returns a new child rule set that applies a custom validation rule.
 // The custom rule is evaluated during validation and any errors it returns are included in the validation result.
 func (ruleSet *IntRuleSet[T]) WithRule(rule Rule[T]) *IntRuleSet[T] {
-	return &IntRuleSet[T]{
-		strict:   ruleSet.strict,
-		rule:     rule,
-		parent:   ruleSet.withoutConflicts(rule),
-		base:     ruleSet.base,
-		required: ruleSet.required,
-		withNil:  ruleSet.withNil,
-		rounding: ruleSet.rounding,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = rule
+	newRuleSet.parent = ruleSet.withoutConflicts(rule)
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.

--- a/pkg/rules/net/domain.go
+++ b/pkg/rules/net/domain.go
@@ -36,6 +36,15 @@ func Domain() *DomainRuleSet {
 	return &baseDomainRuleSet
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (ruleSet *DomainRuleSet) clone() *DomainRuleSet {
+	return &DomainRuleSet{
+		required: ruleSet.required,
+		withNil:  ruleSet.withNil,
+		parent:   ruleSet,
+	}
+}
+
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
 func (ruleSet *DomainRuleSet) Required() bool {
 	return ruleSet.required
@@ -44,24 +53,20 @@ func (ruleSet *DomainRuleSet) Required() bool {
 // WithRequired returns a new rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (ruleSet *DomainRuleSet) WithRequired() *DomainRuleSet {
-	return &DomainRuleSet{
-		required: true,
-		withNil:  ruleSet.withNil,
-		parent:   ruleSet,
-		label:    "WithRequired()",
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (ruleSet *DomainRuleSet) WithNil() *DomainRuleSet {
-	return &DomainRuleSet{
-		required: ruleSet.required,
-		withNil:  true,
-		parent:   ruleSet,
-		label:    "WithNil()",
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // Apply performs a validation of a RuleSet against a value and assigns the result to the output parameter.
@@ -192,13 +197,11 @@ func (ruleSet *DomainRuleSet) noConflict(rule rules.Rule[string]) *DomainRuleSet
 		return ruleSet
 	}
 
-	return &DomainRuleSet{
-		rule:     ruleSet.rule,
-		parent:   newParent,
-		required: ruleSet.required,
-		withNil:  ruleSet.withNil,
-		label:    ruleSet.label,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = ruleSet.rule
+	newRuleSet.parent = newParent
+	newRuleSet.label = ruleSet.label
+	return newRuleSet
 }
 
 // WithRule returns a new child rule set that applies a custom validation rule.
@@ -206,12 +209,10 @@ func (ruleSet *DomainRuleSet) noConflict(rule rules.Rule[string]) *DomainRuleSet
 //
 // Use this when implementing custom rules.
 func (ruleSet *DomainRuleSet) WithRule(rule rules.Rule[string]) *DomainRuleSet {
-	return &DomainRuleSet{
-		rule:     rule,
-		parent:   ruleSet.noConflict(rule),
-		required: ruleSet.required,
-		withNil:  ruleSet.withNil,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = rule
+	newRuleSet.parent = ruleSet.noConflict(rule)
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.

--- a/pkg/rules/net/email.go
+++ b/pkg/rules/net/email.go
@@ -32,6 +32,16 @@ func Email() *EmailRuleSet {
 	return &baseEmailRuleSet
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (ruleSet *EmailRuleSet) clone() *EmailRuleSet {
+	return &EmailRuleSet{
+		required:      ruleSet.required,
+		withNil:       ruleSet.withNil,
+		domainRuleSet: ruleSet.domainRuleSet,
+		parent:        ruleSet,
+	}
+}
+
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
 func (ruleSet *EmailRuleSet) Required() bool {
 	return ruleSet.required
@@ -40,26 +50,20 @@ func (ruleSet *EmailRuleSet) Required() bool {
 // WithRequired returns a new rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (ruleSet *EmailRuleSet) WithRequired() *EmailRuleSet {
-	return &EmailRuleSet{
-		required:      true,
-		withNil:       ruleSet.withNil,
-		parent:        ruleSet,
-		domainRuleSet: ruleSet.domainRuleSet,
-		label:         "WithRequired()",
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (ruleSet *EmailRuleSet) WithNil() *EmailRuleSet {
-	return &EmailRuleSet{
-		required:      ruleSet.required,
-		withNil:       true,
-		parent:        ruleSet,
-		domainRuleSet: ruleSet.domainRuleSet,
-		label:         "WithNil()",
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // Apply performs a validation of a RuleSet against a value and assigns the result to the output parameter.
@@ -194,12 +198,9 @@ func (ruleSet *EmailRuleSet) Evaluate(ctx context.Context, value string) errors.
 //
 //	NewDomain().WithTLD()
 func (ruleSet *EmailRuleSet) WithDomain(domainRuleSet rules.RuleSet[string]) *EmailRuleSet {
-	return &EmailRuleSet{
-		parent:        ruleSet,
-		required:      ruleSet.required,
-		withNil:       ruleSet.withNil,
-		domainRuleSet: domainRuleSet,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.domainRuleSet = domainRuleSet
+	return newRuleSet
 }
 
 // WithRule returns a new child rule set that applies a custom validation rule.
@@ -207,13 +208,9 @@ func (ruleSet *EmailRuleSet) WithDomain(domainRuleSet rules.RuleSet[string]) *Em
 //
 // Use this when implementing custom rules.
 func (ruleSet *EmailRuleSet) WithRule(rule rules.Rule[string]) *EmailRuleSet {
-	return &EmailRuleSet{
-		rule:          rule,
-		parent:        ruleSet,
-		required:      ruleSet.required,
-		withNil:       ruleSet.withNil,
-		domainRuleSet: ruleSet.domainRuleSet,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = rule
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.

--- a/pkg/rules/net/rule_uri_port.go
+++ b/pkg/rules/net/rule_uri_port.go
@@ -8,7 +8,7 @@ import (
 
 // WithMinPort returns a new rule set that validates the port number is at least the specified minimum.
 func (ruleSet *URIRuleSet) WithMinPort(min int) *URIRuleSet {
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.portRuleSet = newRuleSet.portRuleSet.WithMin(min)
 	newRuleSet.label = fmt.Sprintf("WithMinPort(%d)", min)
 	return newRuleSet
@@ -16,7 +16,7 @@ func (ruleSet *URIRuleSet) WithMinPort(min int) *URIRuleSet {
 
 // WithMaxPort returns a new rule set that validates the port number is at most the specified maximum.
 func (ruleSet *URIRuleSet) WithMaxPort(max int) *URIRuleSet {
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.portRuleSet = newRuleSet.portRuleSet.WithMax(max)
 	newRuleSet.label = fmt.Sprintf("WithMaxPort(%d)", max)
 	return newRuleSet
@@ -27,7 +27,7 @@ func (ruleSet *URIRuleSet) WithMaxPort(max int) *URIRuleSet {
 // This method can be called more than once and the allowed values are cumulative.
 // Allowed values must still pass all other rules.
 func (ruleSet *URIRuleSet) WithAllowedPorts(value int, rest ...int) *URIRuleSet {
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.portRuleSet = newRuleSet.portRuleSet.WithAllowedValues(value, rest...)
 
 	list := append([]int{value}, rest...)

--- a/pkg/rules/net/rule_uri_scheme.go
+++ b/pkg/rules/net/rule_uri_scheme.go
@@ -9,7 +9,7 @@ import (
 // This method can be called more than once and the allowed values are cumulative.
 // Allowed values must still pass all other rules.
 func (ruleSet *URIRuleSet) WithAllowedSchemes(value string, rest ...string) *URIRuleSet {
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.schemeRuleSet = newRuleSet.schemeRuleSet.WithAllowedValues(value, rest...)
 
 	list := append([]string{value}, rest...)

--- a/pkg/rules/net/uri.go
+++ b/pkg/rules/net/uri.go
@@ -124,7 +124,7 @@ func (ruleSet *URIRuleSet) WithRequired() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.required = true
 	newRuleSet.label = "WithRequired()"
 	return newRuleSet
@@ -134,7 +134,7 @@ func (ruleSet *URIRuleSet) WithRequired() *URIRuleSet {
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (ruleSet *URIRuleSet) WithNil() *URIRuleSet {
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.withNil = true
 	newRuleSet.label = "WithNil()"
 	return newRuleSet
@@ -147,7 +147,7 @@ func (ruleSet *URIRuleSet) WithUserRequired() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.userRuleSet = newRuleSet.userRuleSet.WithRequired()
 	newRuleSet.label = "WithUserRequired()"
 	return newRuleSet
@@ -160,7 +160,7 @@ func (ruleSet *URIRuleSet) WithPasswordRequired() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.passwordRuleSet = newRuleSet.passwordRuleSet.WithRequired()
 	newRuleSet.label = "WithPasswordRequired()"
 	return newRuleSet
@@ -173,7 +173,7 @@ func (ruleSet *URIRuleSet) WithHostRequired() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.hostRuleSet = newRuleSet.hostRuleSet.WithRequired()
 	newRuleSet.label = "WithHostRequired()"
 	return newRuleSet
@@ -186,7 +186,7 @@ func (ruleSet *URIRuleSet) WithPortRequired() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.portRuleSet = newRuleSet.portRuleSet.WithRequired()
 	newRuleSet.label = "WithPortRequired()"
 	return newRuleSet
@@ -199,7 +199,7 @@ func (ruleSet *URIRuleSet) WithQueryRequired() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.queryRuleSet = newRuleSet.queryRuleSet.WithRequired()
 	newRuleSet.label = "WithQueryRequired()"
 	return newRuleSet
@@ -212,7 +212,7 @@ func (ruleSet *URIRuleSet) WithFragmentRequired() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.fragmentRuleSet = newRuleSet.fragmentRuleSet.WithRequired()
 	newRuleSet.label = "WithFragmentRequired()"
 	return newRuleSet
@@ -247,7 +247,7 @@ func (ruleSet *URIRuleSet) WithDeepErrors() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.deepErrors = true
 	newRuleSet.label = "WithDeepErrors()"
 	return newRuleSet
@@ -268,7 +268,7 @@ func (ruleSet *URIRuleSet) WithRelative() *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(ruleSet)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.relative = true
 	newRuleSet.label = "WithRelative()"
 	return newRuleSet
@@ -654,8 +654,9 @@ func (ruleSet *URIRuleSet) noConflict(rule rules.Rule[string]) *URIRuleSet {
 		return ruleSet
 	}
 
-	newRuleSet := ruleSet.copyWithParent(newParent)
+	newRuleSet := ruleSet.clone()
 	newRuleSet.rule = ruleSet.rule
+	newRuleSet.parent = newParent
 	newRuleSet.label = ruleSet.label
 	return newRuleSet
 }
@@ -677,8 +678,9 @@ func (ruleSet *URIRuleSet) noConflict(rule rules.Rule[string]) *URIRuleSet {
 // - user
 // - password
 func (ruleSet *URIRuleSet) WithRule(rule rules.Rule[string]) *URIRuleSet {
-	newRuleSet := ruleSet.copyWithParent(ruleSet.noConflict(rule))
+	newRuleSet := ruleSet.clone()
 	newRuleSet.rule = rule
+	newRuleSet.parent = ruleSet.noConflict(rule)
 	return newRuleSet
 }
 
@@ -718,10 +720,10 @@ func (ruleSet *URIRuleSet) Any() rules.RuleSet[any] {
 	return rules.WrapAny[string](ruleSet)
 }
 
-// copy creates a rule set with all the appropriate fields copied and the parent set.
-func (ruleSet *URIRuleSet) copyWithParent(newParent *URIRuleSet) *URIRuleSet {
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (ruleSet *URIRuleSet) clone() *URIRuleSet {
 	return &URIRuleSet{
-		parent:           newParent,
+		parent:           ruleSet,
 		schemeRuleSet:    ruleSet.schemeRuleSet,
 		authorityRuleSet: ruleSet.authorityRuleSet,
 		pathRuleSet:      ruleSet.pathRuleSet,

--- a/pkg/rules/object.go
+++ b/pkg/rules/object.go
@@ -126,8 +126,8 @@ func Map[TK comparable, TV any]() *ObjectRuleSet[map[TK]TV, TK, TV] {
 	}
 }
 
-// withParent is a helper function to assist in cloning object RuleSets.
-func (v *ObjectRuleSet[T, TK, TV]) withParent() *ObjectRuleSet[T, TK, TV] {
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (v *ObjectRuleSet[T, TK, TV]) clone() *ObjectRuleSet[T, TK, TV] {
 	return &ObjectRuleSet[T, TK, TV]{
 		allowUnknown: v.allowUnknown,
 		required:     v.required,
@@ -150,7 +150,7 @@ func (v *ObjectRuleSet[T, TK, TV]) WithUnknown() *ObjectRuleSet[T, TK, TV] {
 		return v
 	}
 
-	newRuleSet := v.withParent()
+	newRuleSet := v.clone()
 	newRuleSet.allowUnknown = true
 	newRuleSet.label = "WithUnknown()"
 	return newRuleSet
@@ -253,7 +253,7 @@ func (v *ObjectRuleSet[T, TK, TV]) WithDynamicBucket(keyRule Rule[TK], bucket TK
 //
 // If the only dynamic rules are conditional, the key will be considered unknown if no conditions match.
 func (v *ObjectRuleSet[T, TK, TV]) WithConditionalDynamicBucket(keyRule Rule[TK], condition Conditional[T, TK], bucket TK) *ObjectRuleSet[T, TK, TV] {
-	newRuleSet := v.withParent()
+	newRuleSet := v.clone()
 
 	newRuleSet.key = keyRule
 	newRuleSet.condition = condition
@@ -344,7 +344,7 @@ func (v *ObjectRuleSet[T, TK, TV]) WithConditionalKey(key TK, condition Conditio
 
 // withKeyHelper returns a new rule set with the appropriate keys, conditions, and mappings set.
 func (v *ObjectRuleSet[T, TK, TV]) withKeyHelper(key Rule[TK], destKey TK, condition Conditional[T, TK], ruleSet RuleSet[TV]) *ObjectRuleSet[T, TK, TV] {
-	newRuleSet := v.withParent()
+	newRuleSet := v.clone()
 
 	newRuleSet.mapping = destKey
 	newRuleSet.key = key
@@ -385,7 +385,7 @@ func (v *ObjectRuleSet[T, TK, TV]) WithRequired() *ObjectRuleSet[T, TK, TV] {
 		return v
 	}
 
-	newRuleSet := v.withParent()
+	newRuleSet := v.clone()
 	newRuleSet.required = true
 	newRuleSet.label = "WithRequired()"
 	return newRuleSet
@@ -395,7 +395,7 @@ func (v *ObjectRuleSet[T, TK, TV]) WithRequired() *ObjectRuleSet[T, TK, TV] {
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (v *ObjectRuleSet[T, TK, TV]) WithNil() *ObjectRuleSet[T, TK, TV] {
-	newRuleSet := v.withParent()
+	newRuleSet := v.clone()
 	newRuleSet.withNil = true
 	newRuleSet.label = "WithNil()"
 	return newRuleSet
@@ -871,7 +871,7 @@ func (v *ObjectRuleSet[T, TK, TV]) WithJson() *ObjectRuleSet[T, TK, TV] {
 		return v
 	}
 
-	newRuleSet := v.withParent()
+	newRuleSet := v.clone()
 	newRuleSet.json = true
 	return newRuleSet
 }
@@ -879,7 +879,7 @@ func (v *ObjectRuleSet[T, TK, TV]) WithJson() *ObjectRuleSet[T, TK, TV] {
 // WithRule returns a new child rule set that applies a custom validation rule.
 // The custom rule is evaluated during validation and any errors it returns are included in the validation result.
 func (v *ObjectRuleSet[T, TK, TV]) WithRule(rule Rule[T]) *ObjectRuleSet[T, TK, TV] {
-	newRuleSet := v.withParent()
+	newRuleSet := v.clone()
 	newRuleSet.objRule = rule
 	return newRuleSet
 }

--- a/pkg/rules/object_private_test.go
+++ b/pkg/rules/object_private_test.go
@@ -25,7 +25,7 @@ func (c *alwaysErrorContext) Err() error {
 // TestMissingMapping tests:
 // - Panics when trying to use a key that doesn't have a field mapping
 func TestMissingMapping(t *testing.T) {
-	ruleSet := Struct[*testStruct]().withParent()
+	ruleSet := Struct[*testStruct]().clone()
 
 	// Manually create a mapping that is not on the struct
 	ruleSet.key = Constant("A")
@@ -62,7 +62,7 @@ func TestUnexportedField(t *testing.T) {
 		}
 	}()
 
-	ruleSet := Struct[*testStruct]().withParent()
+	ruleSet := Struct[*testStruct]().clone()
 
 	// Manually create a mapping for the unexported field
 	ruleSet.key = Constant("z")

--- a/pkg/rules/rounding.go
+++ b/pkg/rules/rounding.go
@@ -39,15 +39,10 @@ func (r Rounding) String() string {
 // The RuleSet will attempt to convert floating point numbers to integers even if rounding is not enabled.
 // If the number is not within tolerance (1e-9) of a whole number, an error will be returned.
 func (v *IntRuleSet[T]) WithRounding(rounding Rounding) *IntRuleSet[T] {
-	return &IntRuleSet[T]{
-		strict:   v.strict,
-		parent:   v,
-		base:     v.base,
-		required: v.required,
-		withNil:  v.withNil,
-		rounding: rounding,
-		label:    fmt.Sprintf("WithRounding(%s)", rounding.String()),
-	}
+	newRuleSet := v.clone()
+	newRuleSet.rounding = rounding
+	newRuleSet.label = fmt.Sprintf("WithRounding(%s)", rounding.String())
+	return newRuleSet
 }
 
 // WithRounding returns a new child RuleSet that applies the specified rounding method and precision to floating point numbers.
@@ -57,16 +52,11 @@ func (v *IntRuleSet[T]) WithRounding(rounding Rounding) *IntRuleSet[T] {
 // - Sometimes the rounded result may have additional precision when the rounded number cannot be exactly represented.
 // - For best results, consider using int for your math and data storage/transfer.
 func (v *FloatRuleSet[T]) WithRounding(rounding Rounding, precision int) *FloatRuleSet[T] {
-	return &FloatRuleSet[T]{
-		strict:          v.strict,
-		parent:          v,
-		required:        v.required,
-		withNil:         v.withNil,
-		rounding:        rounding,
-		precision:       precision,
-		outputPrecision: v.outputPrecision,
-		label:           fmt.Sprintf("WithRounding(%s, %d)", rounding.String(), precision),
-	}
+	newRuleSet := v.clone()
+	newRuleSet.rounding = rounding
+	newRuleSet.precision = precision
+	newRuleSet.label = fmt.Sprintf("WithRounding(%s, %d)", rounding.String(), precision)
+	return newRuleSet
 }
 
 // WithFixedOutput returns a new child RuleSet that uses a fixed precision for string output.
@@ -75,14 +65,8 @@ func (v *FloatRuleSet[T]) WithRounding(rounding Rounding, precision int) *FloatR
 //
 // Example: WithFixedOutput(2) will format 123.4 as "123.40" and 123.456 as "123.46" (after rounding if applicable).
 func (v *FloatRuleSet[T]) WithFixedOutput(precision int) *FloatRuleSet[T] {
-	return &FloatRuleSet[T]{
-		strict:          v.strict,
-		parent:          v,
-		required:        v.required,
-		withNil:         v.withNil,
-		rounding:        v.rounding,
-		precision:       v.precision,
-		outputPrecision: precision,
-		label:           fmt.Sprintf("WithFixedOutput(%d)", precision),
-	}
+	newRuleSet := v.clone()
+	newRuleSet.outputPrecision = precision
+	newRuleSet.label = fmt.Sprintf("WithFixedOutput(%d)", precision)
+	return newRuleSet
 }

--- a/pkg/rules/rule_maxlen.go
+++ b/pkg/rules/rule_maxlen.go
@@ -39,14 +39,10 @@ func (rule *maxLenRule[TV, T]) String() string {
 // The maxLen is applied proactively during item processing, stopping validation of items after the maximum
 // length is reached. This allows maxLen to be enforced without requiring all items to be buffered in memory.
 func (v *SliceRuleSet[T]) WithMaxLen(max int) *SliceRuleSet[T] {
-	return &SliceRuleSet[T]{
-		maxLen:   max,
-		parent:   v,
-		required: v.required,
-		withNil:  v.withNil,
-		minLen:   v.minLen,
-		label:    fmt.Sprintf("WithMaxLen(%d)", max),
-	}
+	newRuleSet := v.clone()
+	newRuleSet.maxLen = max
+	newRuleSet.label = fmt.Sprintf("WithMaxLen(%d)", max)
+	return newRuleSet
 }
 
 // WithMaxLen returns a new child RuleSet that is constrained to the provided maximum string length.

--- a/pkg/rules/rule_minlen.go
+++ b/pkg/rules/rule_minlen.go
@@ -38,14 +38,10 @@ func (rule *minLenRule[TV, T]) String() string {
 // WithMinLen returns a new child RuleSet that is constrained to the provided minimum array/slice length.
 // The minLen is checked after all items are processed, ensuring the final output meets the minimum length requirement.
 func (v *SliceRuleSet[T]) WithMinLen(min int) *SliceRuleSet[T] {
-	return &SliceRuleSet[T]{
-		minLen:   min,
-		parent:   v,
-		required: v.required,
-		withNil:  v.withNil,
-		maxLen:   v.maxLen,
-		label:    fmt.Sprintf("WithMinLen(%d)", min),
-	}
+	newRuleSet := v.clone()
+	newRuleSet.minLen = min
+	newRuleSet.label = fmt.Sprintf("WithMinLen(%d)", min)
+	return newRuleSet
 }
 
 // WithMinLen returns a new child RuleSet that is constrained to the provided minimum string length.

--- a/pkg/rules/string.go
+++ b/pkg/rules/string.go
@@ -31,16 +31,23 @@ func String() *StringRuleSet {
 	return &baseStringRuleSet
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (v *StringRuleSet) clone() *StringRuleSet {
+	return &StringRuleSet{
+		strict:   v.strict,
+		required: v.required,
+		withNil:  v.withNil,
+		parent:   v,
+	}
+}
+
 // WithStrict returns a new child RuleSet that disables type coercion.
 // When strict mode is enabled, validation only succeeds if the value is already a string.
 func (v *StringRuleSet) WithStrict() *StringRuleSet {
-	return &StringRuleSet{
-		strict:   true,
-		parent:   v,
-		required: v.required,
-		withNil:  v.withNil,
-		label:    "WithStrict()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.strict = true
+	newRuleSet.label = "WithStrict()"
+	return newRuleSet
 }
 
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
@@ -51,26 +58,20 @@ func (v *StringRuleSet) Required() bool {
 // WithRequired returns a new child rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (v *StringRuleSet) WithRequired() *StringRuleSet {
-	return &StringRuleSet{
-		strict:   v.strict,
-		parent:   v,
-		required: true,
-		withNil:  v.withNil,
-		label:    "WithRequired()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (v *StringRuleSet) WithNil() *StringRuleSet {
-	return &StringRuleSet{
-		strict:   v.strict,
-		parent:   v,
-		required: v.required,
-		withNil:  true,
-		label:    "WithNil()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // Apply performs validation of a RuleSet against a value and assigns the resulting string to the output pointer.
@@ -168,26 +169,20 @@ func (ruleSet *StringRuleSet) noConflict(rule Rule[string]) *StringRuleSet {
 		return ruleSet
 	}
 
-	return &StringRuleSet{
-		rule:     ruleSet.rule,
-		parent:   newParent,
-		required: ruleSet.required,
-		strict:   ruleSet.strict,
-		withNil:  ruleSet.withNil,
-		label:    ruleSet.label,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = ruleSet.rule
+	newRuleSet.parent = newParent
+	newRuleSet.label = ruleSet.label
+	return newRuleSet
 }
 
 // WithRule returns a new child rule set that applies a custom validation rule.
 // The custom rule is evaluated during validation and any errors it returns are included in the validation result.
 func (ruleSet *StringRuleSet) WithRule(rule Rule[string]) *StringRuleSet {
-	return &StringRuleSet{
-		strict:   ruleSet.strict,
-		rule:     rule,
-		parent:   ruleSet.noConflict(rule),
-		required: ruleSet.required,
-		withNil:  ruleSet.withNil,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = rule
+	newRuleSet.parent = ruleSet.noConflict(rule)
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.

--- a/pkg/rules/time/time.go
+++ b/pkg/rules/time/time.go
@@ -33,6 +33,17 @@ func Time() *TimeRuleSet {
 	return &baseTimeRuleSet
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (ruleSet *TimeRuleSet) clone() *TimeRuleSet {
+	return &TimeRuleSet{
+		required:     ruleSet.required,
+		withNil:      ruleSet.withNil,
+		layouts:      ruleSet.layouts,
+		outputLayout: ruleSet.outputLayout,
+		parent:       ruleSet,
+	}
+}
+
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
 func (ruleSet *TimeRuleSet) Required() bool {
 	return ruleSet.required
@@ -41,26 +52,20 @@ func (ruleSet *TimeRuleSet) Required() bool {
 // WithRequired returns a new rule set that requires the value to be present when nested in an object.
 // When a required field is missing from the input, validation fails with an error.
 func (ruleSet *TimeRuleSet) WithRequired() *TimeRuleSet {
-	return &TimeRuleSet{
-		required:     true,
-		withNil:      ruleSet.withNil,
-		parent:       ruleSet,
-		outputLayout: ruleSet.outputLayout,
-		label:        "WithRequired()",
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (ruleSet *TimeRuleSet) WithNil() *TimeRuleSet {
-	return &TimeRuleSet{
-		required:     ruleSet.required,
-		withNil:      true,
-		parent:       ruleSet,
-		outputLayout: ruleSet.outputLayout,
-		label:        "WithNil()",
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // WithLayouts returns a new rule set that allows string-to-time conversion using the specified layouts.
@@ -81,14 +86,10 @@ func (ruleSet *TimeRuleSet) WithLayouts(first string, rest ...string) *TimeRuleS
 	layouts = append(layouts, first)
 	layouts = append(layouts, rest...)
 
-	return &TimeRuleSet{
-		required:     ruleSet.required,
-		withNil:      ruleSet.withNil,
-		layouts:      layouts,
-		parent:       ruleSet,
-		outputLayout: ruleSet.outputLayout,
-		label:        util.StringsToRuleOutput("WithLayouts", layouts),
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.layouts = layouts
+	newRuleSet.label = util.StringsToRuleOutput("WithLayouts", layouts)
+	return newRuleSet
 }
 
 // WithOutputLayout returns a new rule set that formats time values as strings using the specified layout.
@@ -102,13 +103,10 @@ func (ruleSet *TimeRuleSet) WithOutputLayout(layout string) *TimeRuleSet {
 		return ruleSet
 	}
 
-	return &TimeRuleSet{
-		required:     ruleSet.required,
-		withNil:      ruleSet.withNil,
-		parent:       ruleSet,
-		outputLayout: layout,
-		label:        util.StringsToRuleOutput("WithOutputLayout", []string{layout}),
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.outputLayout = layout
+	newRuleSet.label = util.StringsToRuleOutput("WithOutputLayout", []string{layout})
+	return newRuleSet
 }
 
 // Apply performs validation of a RuleSet against a value and assigns the result to the output parameter.
@@ -240,26 +238,20 @@ func (ruleSet *TimeRuleSet) noConflict(rule rules.Rule[time.Time]) *TimeRuleSet 
 		return ruleSet
 	}
 
-	return &TimeRuleSet{
-		rule:         ruleSet.rule,
-		layouts:      ruleSet.layouts,
-		outputLayout: ruleSet.outputLayout,
-		parent:       newParent,
-		required:     ruleSet.required,
-		withNil:      ruleSet.withNil,
-		label:        ruleSet.label,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = ruleSet.rule
+	newRuleSet.parent = newParent
+	newRuleSet.label = ruleSet.label
+	return newRuleSet
 }
 
 // WithRule returns a new child rule set that applies a custom validation rule.
 // The custom rule is evaluated during validation and any errors it returns are included in the validation result.
 func (ruleSet *TimeRuleSet) WithRule(rule rules.Rule[time.Time]) *TimeRuleSet {
-	return &TimeRuleSet{
-		rule:     rule,
-		parent:   ruleSet.noConflict(rule),
-		required: ruleSet.required,
-		withNil:  ruleSet.withNil,
-	}
+	newRuleSet := ruleSet.clone()
+	newRuleSet.rule = rule
+	newRuleSet.parent = ruleSet.noConflict(rule)
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.

--- a/pkg/rules/wrap_any.go
+++ b/pkg/rules/wrap_any.go
@@ -35,6 +35,16 @@ func WrapAny[T any](inner RuleSet[T]) *WrapAnyRuleSet[T] {
 	}
 }
 
+// clone returns a shallow copy of the rule set with parent set to the current instance.
+func (v *WrapAnyRuleSet[T]) clone() *WrapAnyRuleSet[T] {
+	return &WrapAnyRuleSet[T]{
+		required: v.required,
+		withNil:  v.withNil,
+		inner:    v.inner,
+		parent:   v,
+	}
+}
+
 // Required returns a boolean indicating if the value is allowed to be omitted when included in a nested object.
 func (v *WrapAnyRuleSet[T]) Required() bool {
 	return v.required
@@ -46,26 +56,20 @@ func (v *WrapAnyRuleSet[T]) Required() bool {
 // Required defaults to the value of the wrapped RuleSet so if it is already required then there is
 // no need to call this again.
 func (v *WrapAnyRuleSet[T]) WithRequired() *WrapAnyRuleSet[T] {
-	return &WrapAnyRuleSet[T]{
-		required: true,
-		withNil:  v.withNil,
-		inner:    v.inner,
-		parent:   v,
-		label:    "WithRequired()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.required = true
+	newRuleSet.label = "WithRequired()"
+	return newRuleSet
 }
 
 // WithNil returns a new child rule set that allows nil input values.
 // When nil input is provided, validation passes and the output is set to nil (if the output type supports nil values).
 // By default, nil input values return a CodeNull error.
 func (v *WrapAnyRuleSet[T]) WithNil() *WrapAnyRuleSet[T] {
-	return &WrapAnyRuleSet[T]{
-		required: v.required,
-		withNil:  true,
-		inner:    v.inner,
-		parent:   v,
-		label:    "WithNil()",
-	}
+	newRuleSet := v.clone()
+	newRuleSet.withNil = true
+	newRuleSet.label = "WithNil()"
+	return newRuleSet
 }
 
 // evaluateRules runs all the rules and returns any errors.
@@ -141,13 +145,9 @@ func (ruleSet *WrapAnyRuleSet[T]) Evaluate(ctx context.Context, value any) error
 //
 // If you want to add a rule directly to the wrapped RuleSet you must do it before wrapping it.
 func (v *WrapAnyRuleSet[T]) WithRule(rule Rule[any]) *WrapAnyRuleSet[T] {
-	return &WrapAnyRuleSet[T]{
-		required: v.required,
-		withNil:  v.withNil,
-		inner:    v.inner,
-		rule:     rule,
-		parent:   v,
-	}
+	newRuleSet := v.clone()
+	newRuleSet.rule = rule
+	return newRuleSet
 }
 
 // WithRuleFunc returns a new child rule set that applies a custom validation function.


### PR DESCRIPTION
- Introduced a `clone` method in various rule set types to create shallow copies with the current instance as the parent.
- Updated methods like `WithRequired`, `WithForbidden`, `WithNil`, and others to utilize the `clone` method instead of directly constructing new instances.
- This change improves code maintainability and reduces duplication across rule set implementations.